### PR TITLE
Force a player to spectate their own death for a few seconds

### DIFF
--- a/gamemode/server/spectate.lua
+++ b/gamemode/server/spectate.lua
@@ -23,6 +23,10 @@ local function GetSpecEnts(ply)
 end
 
 function GM:PlayerDeathThink(ply)
+    if (CurTime() < ply:GetTimeOfDeath() + TIME_BEFORE_SPECTATE) then
+        return false
+    end
+
     local players = GetSpecEnts(ply)
 
     -- default settings
@@ -59,4 +63,5 @@ end
 hook.Add("PlayerSpawn", "Clear Spectator State", function(ply)
     ply.spectateIndex = nil
     ply.spectateMode = nil
+    ply:SetTimeOfDeath(0)
 end)

--- a/gamemode/shared/player_ext_shd.lua
+++ b/gamemode/shared/player_ext_shd.lua
@@ -91,6 +91,14 @@ function plymeta:SetPropLastChange(time)
     self:SetNWInt("PropLastChange", time)
 end
 
+function plymeta:SetTimeOfDeath(time)
+    self:SetNWFloat("TimeOfDeath", time)
+end
+
+function plymeta:GetTimeOfDeath()
+    return self:GetNWFloat("TimeOfDeath", 0)
+end
+
 --[[=====================]]
 --[[ Taunt-related state ]]
 --[[=====================]]

--- a/gamemode/shared/sh_config.lua
+++ b/gamemode/shared/sh_config.lua
@@ -93,6 +93,12 @@ PROP_ROLL_INCRIMENT = 15
 -- Affects both real death and fake "play dead" death
 PROP_RAGDOLL_DURATION = 8
 
+-- Amount of time a player is given to contemplate their own demise before
+-- going into spectator mode
+-- If this is set to 0, the dead player's ragdoll may spawn in the wrong place,
+-- on top of the player they are spectating
+TIME_BEFORE_SPECTATE = 3
+
 -- Number maps shown to vote on
 MAPS_SHOWN_TO_VOTE = 10
 


### PR DESCRIPTION
This sidesteps a race condition between prop death and ragdoll spawn by having a player spectate their death for a few seconds before moving on to spectate.

By request, left a rare homage to the triple kill bug in. :)