### PR TITLE
Fix fake death respawn

### DIFF
--- a/gamemode/server/player_ext.lua
+++ b/gamemode/server/player_ext.lua
@@ -121,7 +121,6 @@ function plymeta:EndFakeDeath()
     self:ObjSetPlaydead(false)
 
     local ragdoll = self.objRagdoll
-    self:SetPos(ragdoll:GetPos())
     ResetPropToProp(ply)
     self.objRagdoll = nil
     ragdoll:Remove()

--- a/gamemode/shared/utils.lua
+++ b/gamemode/shared/utils.lua
@@ -174,7 +174,13 @@ function FindSpotFor(ply, hbMin, hbMax, searchMultplier)
         end
     end
 
-    return closestToGoal
+    if closestToGoal != nil then
+        return closestToGoal
+    end
+
+    -- default to the original position to avoid spawning at map origin
+    print('Could not find a safe position to spawn prop!')
+    return plyPos
 end
 
 function LerpColor(frac,from,to)

--- a/gamemode/shared/utils.lua
+++ b/gamemode/shared/utils.lua
@@ -179,7 +179,7 @@ function FindSpotFor(ply, hbMin, hbMax, searchMultplier)
     end
 
     -- default to the original position to avoid spawning at map origin
-    print('Could not find a safe position to spawn prop!')
+    print("Could not find a safe position to spawn prop!")
     return plyPos
 end
 

--- a/gamemode/shared/utils.lua
+++ b/gamemode/shared/utils.lua
@@ -91,7 +91,7 @@ function FindSpotFor(ply, hbMin, hbMax, searchMultplier)
     -- traces, but these fields won't change.
     local goalPos = plyPos + Vector(0, 0, zDelta)
     local td = {}
-    td.filter = { ply }
+    td.filter = { ply, ply.objRagdoll }
     if (IsValid(ply:GetProp())) then
         table.insert(td.filter, ply:GetProp())
     end


### PR DESCRIPTION
For whatever reason, the ragdoll's position (post-fake death) is significantly different from the prop's position (pre-fake death), so when the prop tries to respawn it collides with the map, the spawn collision detection can't find a place for it, and it ends up at the map origin.

The spawn collision detection now ignores the player's ragdoll instead of setting the player's position to the ragdoll, and also defaults to the player's previous position instead of returning `nil`.