### PR TITLE
Press F to pay respects

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -58,7 +58,7 @@ net.Receive("Display Respects", function()
     local victim = net.ReadString()
     local victimTeam = net.ReadUInt(16)
     
-    killicon.AddFont(verb, "Sharp HUD", verb, Color(255,255,255,255))
+    killicon.AddFont(verb, "Sharp HUD Small", verb, Color(255,255,255,255))
     GAMEMODE:AddDeathNotice(attacker, attackerTeam, verb, victim, victimTeam)
 end)
 

--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -58,8 +58,8 @@ net.Receive("Display Respects", function()
     local victim = net.ReadString()
     local victimTeam = net.ReadUInt(16)
     
-    killicon.AddFont("kill", "Sharp HUD", verb, Color(255,255,255,255))
-    GAMEMODE:AddDeathNotice(attacker, attackerTeam, "kill", victim, victimTeam)
+    killicon.AddFont(verb, "Sharp HUD", verb, Color(255,255,255,255))
+    GAMEMODE:AddDeathNotice(attacker, attackerTeam, verb, victim, victimTeam)
 end)
 
 net.Receive("Taunt Selection BROADCAST", function()

--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -51,6 +51,17 @@ net.Receive("Death Notice", function()
     GAMEMODE:AddDeathNotice(attacker, attackerTeam, "kill", victim, victimTeam)
 end)
 
+net.Receive("Display Respects", function()
+    local attacker = net.ReadString()
+    local attackerTeam = net.ReadUInt(16)
+    local verb = net.ReadString()
+    local victim = net.ReadString()
+    local victimTeam = net.ReadUInt(16)
+    
+    killicon.AddFont("kill", "Sharp HUD", verb, Color(255,255,255,255))
+    GAMEMODE:AddDeathNotice(attacker, attackerTeam, "kill", victim, victimTeam)
+end)
+
 net.Receive("Taunt Selection BROADCAST", function()
     local taunt = net.ReadString()
     local pitch = net.ReadUInt(8)

--- a/gamemode/client/hotkeys.lua
+++ b/gamemode/client/hotkeys.lua
@@ -36,8 +36,7 @@ end)
 hook.Add("PlayerButtonDown", "PressFToPayRespects", function(ply, button)
     if (CLIENT and
         IsFirstTimePredicted() and
-        button == KEY_F and
-        ply:Team() == TEAM_PROPS
+        button == KEY_F
     ) then
         net.Start("Pay Respects")
         net.SendToServer()

--- a/gamemode/client/hotkeys.lua
+++ b/gamemode/client/hotkeys.lua
@@ -33,6 +33,15 @@ hook.Add("KeyPress", "PressShiftHunterHintUpdown", function(ply, key)
     end
 end)
 
+hook.Add("PlayerButtonDown", "PressFToPayRespects", function(ply, button)
+    if (button == KEY_F and
+         ply:Team() == TEAM_PROPS
+    ) then
+        net.Start("Pay Respects")
+        net.SendToServer()
+    end
+end)
+
 
 function GM:PlayerBindPress(ply, bind, pressed)
     if (ply:Team() == TEAM_PROPS and

--- a/gamemode/client/hotkeys.lua
+++ b/gamemode/client/hotkeys.lua
@@ -34,8 +34,10 @@ hook.Add("KeyPress", "PressShiftHunterHintUpdown", function(ply, key)
 end)
 
 hook.Add("PlayerButtonDown", "PressFToPayRespects", function(ply, button)
-    if (button == KEY_F and
-         ply:Team() == TEAM_PROPS
+    if (CLIENT and
+        IsFirstTimePredicted() and
+        button == KEY_F and
+        ply:Team() == TEAM_PROPS
     ) then
         net.Start("Pay Respects")
         net.SendToServer()

--- a/gamemode/gui/class_selection.lua
+++ b/gamemode/gui/class_selection.lua
@@ -8,6 +8,16 @@ surface.CreateFont("Sharp HUD",
     shadow = true,
 })
 
+surface.CreateFont("Sharp HUD Small",
+{
+    font = "Helvetica",
+    size = 24,
+    weight = 800,
+    antialias = true,
+    outline = false,
+    shadow = true,
+})
+
 local function SendTeam(chosen)
     net.Start("Class Selection")
         net.WriteUInt(chosen, 32)

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -176,7 +176,8 @@ end
 
 function PayRespects(ply)
     local victim = GetLatestVictim()
-    if (victim == nil) then return end
+    -- can't pay respects to yourself or without a victim
+    if (victim == ply or victim == nil) then return end
     local display_string = RESPECTS_VERBS[math.random(#RESPECTS_VERBS)]
     net.Start("Display Respects")
         net.WriteString(ply:Nick())

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -175,7 +175,8 @@ function AnnouncePlayerDeath(ply, attacker)
 end
 
 function PayRespects(ply)
-    local victim = ply --GetLatestVictim()
+    local victim = GetLatestVictim()
+    if (victim == nil) then return end
     local display_string = "found" --random.choice
     net.Start("Display Respects")
         net.WriteString(ply:Nick())

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -174,6 +174,18 @@ function AnnouncePlayerDeath(ply, attacker)
     net.Broadcast()
 end
 
+function PayRespects(ply)
+    local victim = ply --GetLatestVictim()
+    local display_string = "found" --random.choice
+    net.Start("Display Respects")
+        net.WriteString(ply:Nick())
+        net.WriteUInt(ply:Team(), 16)
+        net.WriteString(display_string)
+        net.WriteString(victim:Nick())
+        net.WriteUInt(victim:Team(), 16)
+    net.Broadcast()
+end
+
 -- NOTE: damage from hunters should go through HurtProp, which first rewards
 -- the attacker based on damage dealt and then calls this procedure.  This
 -- procedure merely:

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -177,7 +177,7 @@ end
 function PayRespects(ply)
     local victim = GetLatestVictim()
     if (victim == nil) then return end
-    local display_string = "found" --random.choice
+    local display_string = RESPECTS_VERBS[math.random(#RESPECTS_VERBS)]
     net.Start("Display Respects")
         net.WriteString(ply:Nick())
         net.WriteUInt(ply:Team(), 16)

--- a/gamemode/server/pay_respects.lua
+++ b/gamemode/server/pay_respects.lua
@@ -1,0 +1,25 @@
+--[[============]]--
+--[[PAY RESPECTS]]--
+--[[============]]--
+--
+-- Server-side state and helpers for pressing F to pay respects
+
+local last_dead_player = nil
+
+function GetLatestVictim()
+    return last_dead_player
+end
+
+hook.Add("PlayerDeath", "Store Most Recent Player Death", function(ply)
+    print("player dead")
+
+    if IsValid(ply) then
+        print("setting player dead")
+        print(ply)
+        last_dead_player = ply
+    end
+end)
+
+hook.Add("OBJHUNT_RoundStart", "Reset state for the paying of respects", function()
+    last_dead_player = nil
+end)

--- a/gamemode/server/pay_respects.lua
+++ b/gamemode/server/pay_respects.lua
@@ -5,21 +5,40 @@
 -- Server-side state and helpers for pressing F to pay respects
 
 local last_dead_player = nil
+local fake_dead_players = {}
 
 function GetLatestVictim()
+    if (#fake_dead_players > 0) then
+        return fake_dead_players[#fake_dead_players]
+    end
     return last_dead_player
 end
 
-hook.Add("PlayerDeath", "Store Most Recent Player Death", function(ply)
-    print("player dead")
-
+-- Prop deaths go through the PlayerSilentDeath hook, but that fires
+-- more often than is practical; use this directly when a prop dies
+function RecordPropDeath(ply)
     if IsValid(ply) then
-        print("setting player dead")
-        print(ply)
+        last_dead_player = ply
+    end
+end
+
+function RecordFakePropDeath(ply)
+    if IsValid(ply) then
+        table.insert(fake_dead_players, ply)
+    end
+end
+
+function UndoFakePropDeath()
+    table.remove(fake_dead_players, 1)
+end
+
+hook.Add("PlayerDeath", "Store Most Recent Player Death", function(ply)
+    if IsValid(ply) then
         last_dead_player = ply
     end
 end)
 
 hook.Add("OBJHUNT_RoundStart", "Reset state for the paying of respects", function()
     last_dead_player = nil
+    fake_dead_players = {}
 end)

--- a/gamemode/server/player_ext.lua
+++ b/gamemode/server/player_ext.lua
@@ -86,6 +86,7 @@ function plymeta:PropDeath(attacker, fake)
     attacker:AddFrags(1)
     self:AddDeaths(1)
     self:SetTimeOfDeath(CurTime())
+    RecordPropDeath(ply)
 end
 
 function plymeta:FakeDeath(attacker)
@@ -95,6 +96,7 @@ function plymeta:FakeDeath(attacker)
     self:GetProp():DrawShadow(false)
     self:Freeze(true)
     self:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR)
+    RecordFakePropDeath(ply)
 
     local playDeadDuration = self:ObjGetPlaydeadDuration()
 
@@ -119,6 +121,7 @@ function plymeta:EndFakeDeath()
     self:Freeze(false)
     self:SetCollisionGroup(COLLISION_GROUP_NONE)
     self:ObjSetPlaydead(false)
+    UndoFakePropDeath(ply)
 
     local ragdoll = self.objRagdoll
     ResetPropToProp(ply)

--- a/gamemode/server/player_ext.lua
+++ b/gamemode/server/player_ext.lua
@@ -96,7 +96,7 @@ function plymeta:FakeDeath(attacker)
     self:GetProp():DrawShadow(false)
     self:Freeze(true)
     self:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR)
-    RecordFakePropDeath(ply)
+    RecordFakePropDeath(self)
 
     local playDeadDuration = self:ObjGetPlaydeadDuration()
 
@@ -121,7 +121,7 @@ function plymeta:EndFakeDeath()
     self:Freeze(false)
     self:SetCollisionGroup(COLLISION_GROUP_NONE)
     self:ObjSetPlaydead(false)
-    UndoFakePropDeath(ply)
+    UndoFakePropDeath()
 
     local ragdoll = self.objRagdoll
     ResetPropToProp(ply)

--- a/gamemode/server/sv_receive_net.lua
+++ b/gamemode/server/sv_receive_net.lua
@@ -22,6 +22,8 @@ hook.Add("Initialize", "Precache all network strings", function()
     util.AddNetworkString("Reset To Spawn")
     util.AddNetworkString("Unstick Prop")
     util.AddNetworkString("Ghost Door")
+    util.AddNetworkString("Pay Respects")
+    util.AddNetworkString("Display Respects")
 end)
 
 net.Receive("Class Selection", function(len, ply)
@@ -110,4 +112,9 @@ net.Receive("Ghost Door", function(len, ply)
 
     ply:SetTimeOfNextDoorOpen(CurTime() + PROP_GHOST_DOOR_WAIT)
     door:Fire("Toggle")
+end)
+
+net.Receive("Pay Respects", function(len, ply)
+    -- display shit in the killfeed
+    PayRespects(ply)
 end)

--- a/gamemode/server/sv_receive_net.lua
+++ b/gamemode/server/sv_receive_net.lua
@@ -115,6 +115,5 @@ net.Receive("Ghost Door", function(len, ply)
 end)
 
 net.Receive("Pay Respects", function(len, ply)
-    -- display shit in the killfeed
     PayRespects(ply)
 end)

--- a/gamemode/shared/sh_config.lua
+++ b/gamemode/shared/sh_config.lua
@@ -232,3 +232,15 @@ PROP_TAUNTS["LEEROY... JENKINS!"]           = "taunts/leeroy_jenkins.wav"
 -- USAGE:
 -- HUNTER_TAUNTS["Display Name"] = "taunts/file_name.wav"
 HUNTER_TAUNTS["GlaDoS - President"]         = "taunts/glados-president.wav"
+
+-- For paying respects
+RESPECTS_VERBS = {
+    "paid respects to",
+    "mourned",
+    "left a tribute for",
+    "poured one out for",
+    "observed a moment of silence for",
+    "lit a candle for",
+    "contemplated the fragility of the life of",
+    "dropped an F in the chat for"
+}

--- a/gamemode/shared/sh_config.lua
+++ b/gamemode/shared/sh_config.lua
@@ -242,5 +242,6 @@ RESPECTS_VERBS = {
     "observed a moment of silence for",
     "lit a candle for",
     "contemplated the fragility of the life of",
+    "bowed their head for",
     "dropped an F in the chat for"
 }


### PR DESCRIPTION
After a player dies, other players can press `f` to display their respects in the killfeed.

* This does overlap with the flashlight key for hunters - `f` will toggle both respects and the flashlight ¯\\\_(ツ)_/¯
* Includes the fake death spawn fix from #13